### PR TITLE
Fix typos across site

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,6 @@
     <div class="clear"></div>
 
     <section>
-      <h2 class="clear">    </h2>
       <h2 class="clear">Research focus</h2>
       <ul>
         <li><strong>Quantum algorithms</strong> to tackle quantum simulations of many-body physics, quantum sensing, and quantum information processing.</li>

--- a/projects.html
+++ b/projects.html
@@ -30,10 +30,10 @@
       <!-- -------------------------------------------------------------- -->
       <h2>Krylov Quantum Diagonalization</h2>
       <p>
-        Diagonalizing the Hamiltonian of large, strongly correlated quantum systems can be challeging for classical computers.
+        Diagonalizing the Hamiltonian of large, strongly correlated quantum systems can be challenging for classical computers.
         In this work, we implemented a Krylov subspace quantum algorithm to extract low-energy spectra of
         many-body Hamiltonians on a quantum processor. Shallow
-        Trotter circuits prepare the Krylov subspace and the Hadamrd test returns overlap between subspace vectors. Classical post-processing
+        Trotter circuits prepare the Krylov subspace and the Hadamard test returns overlap between subspace vectors. Classical post-processing
         then yields eigenvalues that rival exact diagonalisation for ~50-site
         lattices.  The technique bridges the gap between variational methods and
         fault-tolerant phase-estimation.
@@ -61,7 +61,7 @@
       <p>
         Qiskit's PEC/PEA toolkit models device noise via sparse Pauli-Lindblad tomography
         and reconstructs an unbiased estimator of the ideal expectation value.  The
-        package streamlines calibration, quasi-probability computation, and resampling, allowing users to seemlessly switch between zero-noise
+        package streamlines calibration, quasi-probability computation, and resampling, allowing users to seamlessly switch between zero-noise
         extrapolation and PEC without rewriting workloads.
       </p>
       <p class="btn-row">
@@ -74,9 +74,9 @@
       <h2>Noise-Aware Qubit Selection</h2>
       <p>
         Qubit quality varies drastically across a quantum processor. To get the best algorithmic performance it is important to choose the best qubits available.
-        The problem of selecting physical qubits for a given circuit is generally refer to as the qubit layout problem. 
+        The problem of selecting physical qubits for a given circuit is generally referred to as the qubit layout problem.
         Qubit characterization routines can provide guidance on the best qubits to use for a given circuit but may require additional resources.
-        One possibility is to use the efficient <a href="https://patents.google.com/patent/US20250165836A1">sparse-noise tomography approach</a> to characterize the Pauil noise channel of the device and use the information for layout selection.
+        One possibility is to use the efficient <a href="https://patents.google.com/patent/US20250165836A1">sparse-noise tomography approach</a> to characterize the Pauli noise channel of the device and use the information for layout selection.
         Alternatively, one can aggregate error rates information (T<sub>1</sub>, T<sub>2</sub>, readout, RB<sub>1q</sub>, RB<sub>2q</sub>) to achieve the same goal.
       </p>
       <p class="btn-row">
@@ -102,7 +102,7 @@
         Calibration of qubit drives generally relies on information about the physics of the system. 
         For large qubit registers, physics-based models fail to capture the full complexity of the system. This translates into sub-optimal performance of the calibration routine.
         In these situations, machine-learning methods like deep reinforcement learning and black-box optimization techniques can be used to discover pulse shapes to
-        improve gate fidelites. The methods autonomously adapts to slow drift and requires no analytic device model.
+        improve gate fidelities. The methods autonomously adapt to slow drift and require no analytic device model.
         These have been integrated as part of Q-CTRL's <a href="https://docs.q-ctrl.com/fire-opal">Fire Opal</a> software package.
       </p>
       <p class="btn-row">


### PR DESCRIPTION
## Summary
- remove an empty `<h2>` from the homepage
- fix several typos in `projects.html`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d9845cbbc832c982bdb904eed209e