### PR TITLE
Fix sticky Jump menu on research page

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -440,8 +440,11 @@ p { max-width: 70ch; }
   font-size: .8rem;
 }
 .toc {
-  position: sticky;
-  top: 1rem;
+  /* The jump menu previously used `position: sticky` so it stayed
+     fixed on screen while scrolling. This caused the menu to overlap
+     the content on long pages, especially on mobile devices. Removing
+     the sticky positioning lets it scroll away with the page. */
+  position: static;
   list-style: none;
   padding-left: 0;
 }


### PR DESCRIPTION
## Summary
- let the Research page jump menu scroll away instead of staying stuck

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684dddc82088832c948a6e2a6536be01