### PR TITLE
Remove Jump menu

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -439,13 +439,3 @@ p { max-width: 70ch; }
   right: 1rem;
   font-size: .8rem;
 }
-.toc {
-  /* The jump menu previously used `position: sticky` so it stayed
-     fixed on screen while scrolling. This caused the menu to overlap
-     the content on long pages, especially on mobile devices. Removing
-     the sticky positioning lets it scroll away with the page. */
-  position: static;
-  list-style: none;
-  padding-left: 0;
-}
-.toc li { margin-bottom:.4rem; }

--- a/research/index.html
+++ b/research/index.html
@@ -24,14 +24,6 @@
       <p>I study how to extract reliable, relevant information from today's noisy superconducting quantum processors. My work spans <em>algorithm design</em>, <em>error-aware control</em>, and hardware <em>benchmarking</em>, with a foundational line in <em>non-stationary cavity quantum electrodynamics</em>.</p>
     </section>
 
-    <aside class="toc">
-      <strong>Jump to</strong>
-      <ul>
-        <li><a href="#algorithms">Quantum Algorithms</a></li>
-        <li><a href="#mitigation">Error Mitigation &amp; Control</a></li>
-        <li><a href="#qed">Non‑stationary Cavity QED</a></li>
-      </ul>
-    </aside>
 
     <section id="algorithms">
       <h2>Quantum algorithms</h2>


### PR DESCRIPTION
## Summary
- remove 'Jump to' aside from research
- clean up unused `.toc` styles

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684ddfbca368832ca363f5fd084b6ac6