### PR TITLE
Add dark mode toggle

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -16,6 +16,7 @@
         <a href="/research/">Research</a> ·
         <a href="/cv.html">CV</a> ·
         <a href="/contact.html">Contact</a>
+        <button class="button u-pull-right" onclick="toggleTheme()" aria-label="Toggle dark mode">🌓</button>
       </nav>
       <hr>
     </header>
@@ -33,5 +34,6 @@
 
     <footer><hr><small>&copy; 2025 Mirko Amico</small></footer>
   </div>
+  <script src="/js/theme-toggle.js"></script>
 </body>
 </html>

--- a/css/styles.css
+++ b/css/styles.css
@@ -439,3 +439,28 @@ p { max-width: 70ch; }
   right: 1rem;
   font-size: .8rem;
 }
+
+/* Dark mode overrides */
+html.dark {
+  background:#121212;
+  color:#e0e0e0;
+}
+html.dark body { background:#121212; color:#e0e0e0; }
+html.dark a { color:#80d0ff; }
+html.dark a:hover { color:#b3e5ff; }
+html.dark hr { border-top-color:#444; }
+html.dark .card { border-color:#444; background:#1b1b1b; box-shadow:0 2px 4px rgba(0,0,0,0.6); }
+html.dark input,
+html.dark textarea,
+html.dark select {
+  background:#222;
+  color:#e0e0e0;
+  border-color:#555;
+}
+html.dark code {
+  background:#222;
+  border-color:#333;
+}
+html.dark pre > code {
+  background:#222;
+}

--- a/cv.html
+++ b/cv.html
@@ -99,6 +99,7 @@
         <a href="/research/">Research</a> ·
         <a href="/cv.html">CV</a> ·
         <a href="/contact.html">Contact</a>
+        <button class="button u-pull-right" onclick="toggleTheme()" aria-label="Toggle dark mode">🌓</button>
       </nav>
       <hr>
     </header>
@@ -175,5 +176,6 @@
 
     <footer><hr><small>Last updated 2025 • © Mirko Amico</small></footer>
   </div>
+  <script src="/js/theme-toggle.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@
         <a href="/research/">Research</a> ·
         <a href="/cv.html">CV</a> ·
         <a href="/contact.html">Contact</a>
+        <button class="button u-pull-right" onclick="toggleTheme()" aria-label="Toggle dark mode">🌓</button>
       </nav>
       <hr>
     </header>
@@ -53,5 +54,6 @@
 
     <footer><hr><small>&copy; 2025 Mirko Amico</small></footer>
   </div>
+  <script src="/js/theme-toggle.js"></script>
 </body>
 </html>

--- a/js/theme-toggle.js
+++ b/js/theme-toggle.js
@@ -1,0 +1,11 @@
+(() => {
+  const root = document.documentElement;
+  const stored = localStorage.getItem('theme');
+  if (stored === 'dark' || (!stored && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+    root.classList.add('dark');
+  }
+  window.toggleTheme = () => {
+    root.classList.toggle('dark');
+    localStorage.setItem('theme', root.classList.contains('dark') ? 'dark' : 'light');
+  };
+})();

--- a/research/index.html
+++ b/research/index.html
@@ -16,6 +16,7 @@
         <a href="/research/">Research</a> ·
         <a href="/cv.html">CV</a> ·
         <a href="/contact.html">Contact</a>
+        <button class="button u-pull-right" onclick="toggleTheme()" aria-label="Toggle dark mode">🌓</button>
       </nav>
       <hr>
     </header>
@@ -132,5 +133,6 @@ if(input){
   });
 }
 </script>
+<script src="/js/theme-toggle.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add `theme-toggle.js` to control a `.dark` class on the root element
- add dark mode override styles in `styles.css`
- include dark-mode toggle button on every page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684de04ad8cc832ca250636f7f351507