### PR TITLE
Fix thesis link in research page

### DIFF
--- a/research/index.html
+++ b/research/index.html
@@ -95,10 +95,10 @@
       <p>At the heart of many superconducting devices is a tunable qubit-cavity coupling. My doctoral work focused on non-adiabatic effects, the dynamical Lamb and Casimir effects, arising during fast qubit driving. Modeling of superconducting circuits shows that these effects can be used to generate entanglement and perform ultra-fast quantum gates.</p>
 
       <div class="card" id="qed-thesis">
-        <h4>Bachelor &amp; Master Theses</h4>
+        <h4>Dynamical Lamb effect</h4>
         <p>Student research on entanglement generation via the dynamical Lamb effect.</p>
         <p>
-          <a class="button button-primary" href="../assets/files/master-thesis.pdf">Thesis</a>
+          <a class="button button-primary" href="https://academicworks.cuny.edu/gc_etds/3699/">Thesis</a>
           <a class="button" href="https://github.com/miamico/dynamical-Lamb-effect">Code</a>
         </p>
       </div>


### PR DESCRIPTION
## Summary
- update the thesis card title
- link directly to thesis on CUNY site

## Testing
- `html5validator --root .`

------
https://chatgpt.com/codex/tasks/task_e_684de36cd740832c9fb267c20600fe75