### PR TITLE
Remove years from research card titles

### DIFF
--- a/research/index.html
+++ b/research/index.html
@@ -31,7 +31,7 @@
       <p>I develop and implement quantum algorithms to measure quantities of interest, stay within the coherence budget of noisy hardware. Highlights include Krylov-subspace diagonalisation of ~50-site spin lattices, the first experimental extraction of conformal-field-theory central charge on a universal processor, and early demonstrations that qubit-level matched filtering can recover astrophysical signals at classical signal-to-noise ratios. All of these share a guiding principle: pair modest quantum circuits with classical post-processing to reach classically intractable regimes sooner.</p>
 
       <div class="card" id="kqd">
-        <h4>Krylov Quantum Diagonalization — 2024</h4>
+        <h4>Krylov Quantum Diagonalization</h4>
         <p>Diagonalizing large many-body Hamiltonians via shallow Trotter circuits and classical post-processing.</p>
         <p>
           <a class="button button-primary" href="https://arxiv.org/abs/2407.14431">Paper</a>
@@ -40,7 +40,7 @@
       </div>
 
       <div class="card" id="mpf">
-        <h4>Tensor-network-enhanced MPF — 2024</h4>
+        <h4>Tensor-network-enhanced MPF</h4>
         <p>Compressing time-evolution circuits using multiproduct formulas assisted by tensor networks.</p>
         <p>
           <a class="button button-primary" href="https://arxiv.org/abs/2407.17405">Paper</a>
@@ -63,7 +63,7 @@
       </div>
 
       <div class="card" id="qubits">
-        <h4>Noise-Aware Qubit Selection — 2025</h4>
+        <h4>Noise-Aware Qubit Selection</h4>
         <p>Choosing the best qubits using sparse noise tomography or aggregated error metrics.</p>
         <p>
           <a class="button button-primary" href="https://patents.google.com/patent/US20250165836A1">Patent</a>
@@ -72,7 +72,7 @@
       </div>
 
       <div class="card" id="cac">
-        <h4>Context-Aware Compiling — 2024</h4>
+        <h4>Context-Aware Compiling</h4>
         <p>Mitigating correlated noise at compile time via targeted dynamical decoupling.</p>
         <p>
           <a class="button button-primary" href="https://arxiv.org/abs/2403.06852">Paper</a>
@@ -81,7 +81,7 @@
       </div>
 
       <div class="card" id="drldesign">
-        <h4>Error-Robust Gate-Set Design — 2021</h4>
+        <h4>Error-Robust Gate-Set Design</h4>
         <p>Using deep reinforcement learning and black-box optimization to autonomously calibrate high-fidelity gates.</p>
         <p>
           <a class="button button-primary" href="https://doi.org/10.1103/PRXQuantum.2.040324">Paper</a>


### PR DESCRIPTION
## Summary
- clean up research page titles by removing years from project cards

## Testing
- `grep -n "<h4>" research/index.html`

------
https://chatgpt.com/codex/tasks/task_e_684de4d37dd4832ca916efd357c72504