### PR TITLE
Remove employer info from Home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,15 +29,13 @@
 
     <section>
       <img src="assets/images/avatar.jpeg" alt="Mirko Amico" class="avatar">
-      <p class="intro-line">Technical Lead at IBM Quantum exploring quantum algorithms and error mitigation.</p>
+      <p class="intro-line">Researcher exploring quantum algorithms and error mitigation.</p>
     </section>
     <div class="clear"></div>
 
     <section>
-      <p>I am based in New York, currently a Technical Lead at <a href="https://www.ibm.com/quantum">IBM Quantum</a>. My work spans algorithm design and error-mitigation tools for near-term devices.</p>
+      <p>My work spans algorithm design and error-mitigation tools for near-term devices.</p>
       <ul>
-        <li><strong>Location:</strong> New York, USA</li>
-        <li><strong>Employer:</strong> IBM Quantum</li>
         <li><a href="cv.html">Full CV</a> · <a href="contact.html">Contact info</a></li>
       </ul>
     </section>


### PR DESCRIPTION
## Summary
- update Home page to omit employer and location

## Testing
- `pip install html5validator`
- `html5validator --root .`


------
https://chatgpt.com/codex/tasks/task_e_684de56a2f88832cbfe23d213b9a248d