### PR TITLE
Simplify dark mode toggle

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -16,7 +16,7 @@
         <a href="/research/">Research</a> ·
         <a href="/cv.html">CV</a> ·
         <a href="/contact.html">Contact</a>
-        <button class="button u-pull-right" onclick="toggleTheme()" aria-label="Toggle dark mode">🌓</button>
+        <button class="theme-toggle u-pull-right" onclick="toggleTheme()" aria-label="Toggle dark mode"></button>
       </nav>
       <hr>
     </header>

--- a/css/styles.css
+++ b/css/styles.css
@@ -433,6 +433,14 @@ p { max-width: 70ch; }
   font-size:.7rem;
   margin-left:.4rem;
 }
+.theme-toggle {
+  background:none;
+  border:none;
+  font-size:1.5rem;
+  cursor:pointer;
+  line-height:1;
+  padding:0;
+}
 .back-to-top {
   position: fixed;
   bottom: 1rem;

--- a/cv.html
+++ b/cv.html
@@ -99,7 +99,7 @@
         <a href="/research/">Research</a> ·
         <a href="/cv.html">CV</a> ·
         <a href="/contact.html">Contact</a>
-        <button class="button u-pull-right" onclick="toggleTheme()" aria-label="Toggle dark mode">🌓</button>
+        <button class="theme-toggle u-pull-right" onclick="toggleTheme()" aria-label="Toggle dark mode"></button>
       </nav>
       <hr>
     </header>

--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
         <a href="/research/">Research</a> ·
         <a href="/cv.html">CV</a> ·
         <a href="/contact.html">Contact</a>
-        <button class="button u-pull-right" onclick="toggleTheme()" aria-label="Toggle dark mode">🌓</button>
+        <button class="theme-toggle u-pull-right" onclick="toggleTheme()" aria-label="Toggle dark mode"></button>
       </nav>
       <hr>
     </header>

--- a/js/theme-toggle.js
+++ b/js/theme-toggle.js
@@ -1,11 +1,19 @@
 (() => {
   const root = document.documentElement;
+  const toggles = document.querySelectorAll('.theme-toggle');
   const stored = localStorage.getItem('theme');
+  const applyIcon = () => {
+    toggles.forEach(btn => {
+      btn.textContent = root.classList.contains('dark') ? '☀' : '☾';
+    });
+  };
   if (stored === 'dark' || (!stored && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
     root.classList.add('dark');
   }
+  applyIcon();
   window.toggleTheme = () => {
     root.classList.toggle('dark');
     localStorage.setItem('theme', root.classList.contains('dark') ? 'dark' : 'light');
+    applyIcon();
   };
 })();

--- a/research/index.html
+++ b/research/index.html
@@ -16,7 +16,7 @@
         <a href="/research/">Research</a> ·
         <a href="/cv.html">CV</a> ·
         <a href="/contact.html">Contact</a>
-        <button class="button u-pull-right" onclick="toggleTheme()" aria-label="Toggle dark mode">🌓</button>
+        <button class="theme-toggle u-pull-right" onclick="toggleTheme()" aria-label="Toggle dark mode"></button>
       </nav>
       <hr>
     </header>


### PR DESCRIPTION
## Summary
- restyle the theme toggle button
- simplify HTML markup for all pages
- update JavaScript to switch between sun/moon icons

## Testing
- `npm test` *(fails: no package.json)*
- `pytest`
- `html5validator --root .`


------
https://chatgpt.com/codex/tasks/task_e_684de73c3db0832ca6bb65b9f45d54ab