### PR TITLE
Improve homepage tagline and CTA

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -472,3 +472,15 @@ html.dark code {
 html.dark pre > code {
   background:#222;
 }
+
+/* Homepage extras */
+.tagline {
+  font-size:1.2rem;
+  font-weight:600;
+  margin-top:0.5rem;
+}
+
+.cta {
+  font-size:1.1rem;
+  padding:0.6rem 2rem;
+}

--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
   <div class="container">
     <header>
       <h1>Mirko&nbsp;Amico</h1>
+      <p class="tagline">I design error-mitigated quantum algorithms so physicists can run meaningful experiments on today’s noisy processors.</p>
       <p>Quantum Algorithms · Error Mitigation · Benchmarking · cavity QED</p>
       <nav>
         <a href="/index.html">Home</a> ·
@@ -47,7 +48,7 @@
         <li><a href="research/#mpf">Tensor-network-enhanced time evolution</a> (2024)</li>
         <li><a href="research/#cac">Context-aware compiling for correlated noise</a> (2024)</li>
       </ul>
-      <p><a class="button" href="research/">Explore Research</a></p>
+      <p><a class="button button-primary cta" href="research/">Dive into my research</a></p>
     </section>
 
     <footer><hr><small>&copy; 2025 Mirko Amico</small></footer>


### PR DESCRIPTION
## Summary
- add tagline explaining value and audience
- make research button dominant and rename to "Dive into my research"
- add CSS for tagline and call-to-action

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684de8cb2aac832cb3a9bded91271e12