### PR TITLE
Implement pill filter for publications

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -439,6 +439,23 @@ a:hover {
   font-size:.7rem;
   margin-left:.4rem;
 }
+
+/* Publication filter pills */
+.pill {
+  display:inline-block;
+  padding:0.3rem 0.6rem;
+  margin:0 0.3rem 0.6rem 0;
+  border:1px solid #bbb;
+  border-radius:9999px;
+  background:#f7f7f7;
+  cursor:pointer;
+  font-size:0.8rem;
+}
+.pill.active{
+  background:#5567ff;
+  color:#fff;
+  border-color:#5567ff;
+}
 .theme-toggle {
   background:none;
   border:none;
@@ -471,6 +488,14 @@ html.dark select {
   background:#222;
   color:#e0e0e0;
   border-color:#555;
+}
+html.dark .pill {
+  background:#333;
+  border-color:#555;
+}
+html.dark .pill.active{
+  background:#8899ff;
+  border-color:#8899ff;
 }
 html.dark code {
   background:#222;

--- a/research/index.html
+++ b/research/index.html
@@ -108,12 +108,12 @@
 
     <section id="publications">
       <h2>Publications &amp; Preprints</h2>
-      <select id="tagFilter" class="u-full-width">
-        <option value="">All tags</option>
-        <option value="mitigation">Mitigation</option>
-        <option value="algorithms">Algorithms</option>
-        <option value="qed">QED</option>
-      </select>
+      <div id="tagFilters" class="u-full-width">
+        <span class="pill active" data-tag="">All</span>
+        <span class="pill" data-tag="mitigation">Mitigation</span>
+        <span class="pill" data-tag="algorithms">Algorithms</span>
+        <span class="pill" data-tag="qed">QED</span>
+      </div>
       <ul id="pubList">
         <li data-tags="mitigation"><strong>2025</strong> – M. Amico <em>et al.</em>, <a href="https://patents.google.com/patent/US20250165836A1">Sparse noise tomography‑based qubit mapping</a>, US Patent 20250165836A1. <span class="tag">Mitigation</span></li>
 
@@ -143,16 +143,39 @@
   </div>
 
 <script>
-const select = document.getElementById('tagFilter');
-if(select){
-  select.addEventListener('change', function(){
-    const tag = this.value.toLowerCase();
-    document.querySelectorAll('#pubList li').forEach(li => {
-      const tags = li.dataset.tags || '';
-      li.style.display = !tag || tags.toLowerCase().includes(tag) ? '' : 'none';
-    });
+const pills = document.querySelectorAll('#tagFilters .pill');
+const allPill = document.querySelector('#tagFilters .pill[data-tag=""]');
+const selected = new Set();
+
+function filterPubs(){
+  document.querySelectorAll('#pubList li').forEach(li => {
+    const tags = (li.dataset.tags || '').toLowerCase();
+    const show = selected.size === 0 || [...selected].some(t => tags.includes(t));
+    li.style.display = show ? '' : 'none';
   });
 }
+
+pills.forEach(pill => pill.addEventListener('click', () => {
+  const tag = pill.dataset.tag.toLowerCase();
+  if(tag === ''){
+    selected.clear();
+    pills.forEach(p => p.classList.remove('active'));
+    pill.classList.add('active');
+  } else {
+    pill.classList.toggle('active');
+    if(pill.classList.contains('active')){
+      selected.add(tag);
+    } else {
+      selected.delete(tag);
+    }
+    if(selected.size === 0){
+      allPill.classList.add('active');
+    } else {
+      allPill.classList.remove('active');
+    }
+  }
+  filterPubs();
+}));
 </script>
 <script src="/js/theme-toggle.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- replace dropdown filter on research page with pill-based filter
- style pills and add dark mode support
- update JS filtering logic

## Testing
- `html5validator --root . --verbose`

------
https://chatgpt.com/codex/tasks/task_e_684dfeb4f710832c8f5a3b5262fcb76e