### PR TITLE
Fix card height on research page

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -447,6 +447,10 @@ a:hover {
 .card-grid .card {
   margin-bottom: 0;
   max-width: 200px;
+  height: 220px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
 }
 .tag {
   display: inline-block;


### PR DESCRIPTION
## Summary
- make research page cards a consistent height

## Testing
- `bash -lc 'tidy --version'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e02a2479c832cbfbe3bbe4a33f821