### PR TITLE
Improve card layout styles

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -425,11 +425,20 @@ a:hover {
   text-decoration: underline;
 }
 .card {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
   border: 1px solid #B0B0B0;
-  padding: 0.8rem;
+  padding: 1rem;
   margin-bottom: 1rem;
   border-radius: 6px;
   box-shadow: 0 2px 4px rgba(0,0,0,0.04);
+  transition: box-shadow 0.2s;
+}
+
+.card:hover,
+.card:focus-within {
+  box-shadow: 0 4px 8px rgba(0,0,0,0.1);
 }
 
 .card h4 {
@@ -439,18 +448,13 @@ a:hover {
 
 .card-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.5rem;
   justify-items: center;
 }
 
 .card-grid .card {
   margin-bottom: 0;
-  max-width: 200px;
-  height: 220px;
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
 }
 .tag {
   display: inline-block;
@@ -460,6 +464,19 @@ a:hover {
   font-size:.7rem;
   margin-left:.4rem;
 }
+
+.chip {
+  display:inline-block;
+  padding:0 .4rem;
+  font-size:.7rem;
+  border-radius:9999px;
+  margin-right:.4rem;
+  background:#eef;
+}
+.chip.paper  { background:#d0ebff; color:#003366; }
+.chip.code   { background:#e6ffe7; color:#004d1a; }
+.chip.talk   { background:#ffe7d6; color:#663300; }
+.chip.patent { background:#f5e6ff; color:#330033; }
 
 /* Publication filter pills */
 .pill {
@@ -502,6 +519,8 @@ html.dark a { color:#80d0ff; }
 html.dark a:hover { color:#b3e5ff; }
 html.dark hr { border-top-color:#444; }
 html.dark .card { border-color:#444; background:#1b1b1b; box-shadow:0 2px 4px rgba(0,0,0,0.6); }
+html.dark .card:hover,
+html.dark .card:focus-within { box-shadow:0 4px 8px rgba(0,0,0,0.8); }
 html.dark .tag { color:#000; }
 html.dark input,
 html.dark textarea,


### PR DESCRIPTION
## Summary
- update `.card` styles for flexbox layout and shadow
- make `.card-grid` responsive with flexible columns
- drop width/height limits from `.card-grid .card`
- add interactive card hover states
- introduce `.chip` badges with themed variants
- tweak dark mode card hover shadow

## Testing
- `html5validator --root .`

------
https://chatgpt.com/codex/tasks/task_e_684e05752db4832c87972bf16bdff1de