### PR TITLE
Use CSS custom properties for card styling

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -417,6 +417,17 @@ there.
 /* Larger than Desktop HD */
 @media (min-width: 1200px) {}
 /* --- Custom tweaks --- */
+:root {
+  --card-bg: #fff;
+  --card-border: #B0B0B0;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --card-bg: #1b1b1b;
+    --card-border: #444;
+  }
+}
 .container {
   max-width: 70ch;
 }
@@ -425,7 +436,8 @@ a:hover {
   text-decoration: underline;
 }
 .card {
-  border: 1px solid #B0B0B0;
+  border: 1px solid var(--card-border);
+  background: var(--card-bg);
   padding: 0.8rem;
   margin-bottom: 1rem;
   border-radius: 6px;
@@ -496,12 +508,13 @@ a:hover {
 html.dark {
   background:#121212;
   color:#e0e0e0;
+  --card-bg: #1b1b1b;
+  --card-border: #444;
 }
 html.dark body { background:#121212; color:#e0e0e0; }
 html.dark a { color:#80d0ff; }
 html.dark a:hover { color:#b3e5ff; }
 html.dark hr { border-top-color:#444; }
-html.dark .card { border-color:#444; background:#1b1b1b; box-shadow:0 2px 4px rgba(0,0,0,0.6); }
 html.dark .tag { color:#000; }
 html.dark input,
 html.dark textarea,


### PR DESCRIPTION
## Summary
- define `--card-bg` and `--card-border` custom properties
- use the variables in `.card` styles
- update the variables for dark mode using media query and `html.dark`
- remove hard-coded dark mode card styles

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684e057679bc832c808c451702dbb335