### PR TITLE
Improve card accessibility and focus styles

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -430,6 +430,18 @@ a:hover {
   margin-bottom: 1rem;
   border-radius: 6px;
   box-shadow: 0 2px 4px rgba(0,0,0,0.04);
+  transition: box-shadow 0.2s;
+}
+
+.card:hover,
+.card:focus-visible {
+  box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+}
+
+.card:focus-visible,
+.card:focus-within {
+  outline: 2px solid #5567ff;
+  outline-offset: 2px;
 }
 
 .card h4 {
@@ -502,6 +514,10 @@ html.dark a { color:#80d0ff; }
 html.dark a:hover { color:#b3e5ff; }
 html.dark hr { border-top-color:#444; }
 html.dark .card { border-color:#444; background:#1b1b1b; box-shadow:0 2px 4px rgba(0,0,0,0.6); }
+html.dark .card:hover,
+html.dark .card:focus-visible {
+  box-shadow: 0 4px 8px rgba(0,0,0,0.8);
+}
 html.dark .tag { color:#000; }
 html.dark input,
 html.dark textarea,

--- a/research/index.html
+++ b/research/index.html
@@ -30,7 +30,7 @@
       <p>I develop and implement quantum algorithms to measure quantities of interest, stay within the coherence budget of noisy hardware. Highlights include Krylov-subspace diagonalisation of ~50-site spin lattices, the first experimental extraction of conformal-field-theory central charge on a universal processor, and early demonstrations that qubit-level matched filtering can recover astrophysical signals at classical signal-to-noise ratios. All of these share a guiding principle: pair modest quantum circuits with classical post-processing to reach classically intractable regimes sooner.</p>
 
       <div class="card-grid">
-      <div class="card" id="kqd">
+      <div class="card" id="kqd" tabindex="0">
         <h4>Krylov Quantum Diagonalization</h4>
         <p>Diagonalizing large many-body Hamiltonians via shallow Trotter circuits and classical post-processing.</p>
         <p>
@@ -47,7 +47,7 @@
       <p>Reliable algorithms require hardware-aware error suppression and mitigation. I build tools for: autonomous calibration of control pulses based on deep-reinforcement-learning and black-box optimization techniques; compiler techniques to reduce crosstalk via dynamical decoupling sequences; qubit selection protocols based on efficient sparse-noise tomography to execute the algorithm on the best performing qubits. These ideas extend into algorithmic space: I've recently started to explore tensor-network-assisted algorithm implementation, like multiproduct formulas, to improve performance without sacrificing circuit depth. Across all projects the aim is the same: suppress dominant errors <em>in situ</em> so mitigation overhead stays manageable.</p>
 
       <div class="card-grid">
-      <div class="card" id="mpf">
+      <div class="card" id="mpf" tabindex="0">
         <h4>Tensor-network-enhanced MPF</h4>
         <p>Compressing time-evolution circuits using multiproduct formulas assisted by tensor networks.</p>
         <p>
@@ -56,7 +56,7 @@
         </p>
       </div>
 
-      <div class="card" id="pec">
+      <div class="card" id="pec" tabindex="0">
         <h4>Probabilistic error cancellation and amplification</h4>
         <p>Toolkit for modeling device noise and reconstructing unbiased expectation values using quasi-probability techniques.</p>
         <p>
@@ -65,7 +65,7 @@
         </p>
       </div>
 
-      <div class="card" id="qubits">
+      <div class="card" id="qubits" tabindex="0">
         <h4>Noise-Aware Qubit Selection</h4>
         <p>Choosing the best qubits using sparse noise tomography or aggregated error metrics.</p>
         <p>
@@ -74,7 +74,7 @@
         </p>
       </div>
 
-      <div class="card" id="cac">
+      <div class="card" id="cac" tabindex="0">
         <h4>Context-Aware Compiling</h4>
         <p>Mitigating correlated noise at compile time via targeted dynamical decoupling.</p>
         <p>
@@ -83,7 +83,7 @@
         </p>
       </div>
 
-        <div class="card" id="drldesign">
+        <div class="card" id="drldesign" tabindex="0">
           <h4>Error-Robust Gate-Set Design</h4>
           <p>Using deep reinforcement learning and black-box optimization to autonomously calibrate high-fidelity gates.</p>
           <p>
@@ -101,7 +101,7 @@
       <p>At the heart of many superconducting devices is a tunable qubit-cavity coupling. My doctoral work focused on non-adiabatic effects, the dynamical Lamb and Casimir effects, arising during fast qubit driving. Modeling of superconducting circuits shows that these effects can be used to generate entanglement and perform ultra-fast quantum gates.</p>
 
       <div class="card-grid">
-      <div class="card" id="qed-thesis">
+      <div class="card" id="qed-thesis" tabindex="0">
         <h4>Dynamical Lamb effect</h4>
         <p>Entanglement generation in non-stationary cavity QED via the dynamical Lamb effect.</p>
         <p>


### PR DESCRIPTION
## Summary
- make cards keyboard focusable with `tabindex`
- show focus ring and consistent shadow on cards
- update dark mode card hover/focus shadow

## Testing
- `tidy -quiet research/index.html`

------
https://chatgpt.com/codex/tasks/task_e_684e057597ec832ca4afeb4442d15f98