### PR TITLE
Adjust research page spacing

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -462,6 +462,7 @@ a:hover {
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
   gap: 1.5rem;
   justify-items: center;
+  margin-bottom: 3rem;
 }
 
 .card-grid .card {


### PR DESCRIPTION
## Summary
- add bottom margin to card grids for clearer separation between sections

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684e23c92e4c832cb5c21a5416ba5096